### PR TITLE
fix: Use fixed link to get it to work on org profile

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -5,6 +5,6 @@ What are you up to?
 - Starting a new Git repo? Make sure to [use our template](https://github.com/Codit/template)
 - Need to invite a co-worker to our organization? Open a support ticket with internal IT.
 
-Enjoy contributing to our GitHub repos, but ensure you have [logged in with your Azure AD account](./single-sign-on.md) to get the most out of our repos.
+Enjoy contributing to our GitHub repos, but ensure you have [logged in with your Azure AD account](https://github.com/Codit/.github/blob/main/profile/single-sign-on.md) to get the most out of our repos.
 
 Are you interested in joining Codit? Good news - [We are hiring](https://codit.eu/jobs)!


### PR DESCRIPTION
Use fixed link to get it to work on org profile since it uses repo root there, while in the individual file it will check the same folder.